### PR TITLE
Feat/#10 입주민 외부인 출입

### DIFF
--- a/backend/src/main/java/com/ohammer/apartner/domain/user/repository/UserRepository.java
+++ b/backend/src/main/java/com/ohammer/apartner/domain/user/repository/UserRepository.java
@@ -65,4 +65,26 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     @Query("SELECT u FROM User u JOIN FETCH u.building JOIN FETCH u.unit WHERE u.id = :id")
     Optional<User> findByIdWithBuildingAndUnit(@Param("id") Long id);
+
+
+    //Optional<User> findByBuilding_BuildingNumberAndUnit_UnitNumber(String buildingNum, String unitNum);
+
+
+    @Query("""
+        SELECT u FROM User u
+         JOIN u.apartment a
+         JOIN u.building b
+         JOIN u.unit   t
+        WHERE a.name       = :aptName
+          AND b.buildingNumber = :bldgNum
+          AND t.unitNumber     = :unitNum
+      """)
+    Optional<User> findByAptAndBuildingAndUnit(
+            @Param("aptName") String aptName,
+            @Param("bldgNum") String bldgNum,
+            @Param("unitNum") String unitNum
+    );
+
+
+
 }

--- a/backend/src/main/java/com/ohammer/apartner/domain/vehicle/controller/EntryRecordController.java
+++ b/backend/src/main/java/com/ohammer/apartner/domain/vehicle/controller/EntryRecordController.java
@@ -37,8 +37,8 @@ public class EntryRecordController {
 
     // 🚙 출차
     @PostMapping("/exit")
-    public ResponseEntity<EntryRecordResponseDto> exit() { // @RequestBody EntryRecordRequestDto dto
-        return ResponseEntity.ok(entryRecordService.exitVehicle());
+    public ResponseEntity<EntryRecordResponseDto> exit(@RequestBody EntryRecordRequestDto dto) { // @RequestBody EntryRecordRequestDto dto
+        return ResponseEntity.ok(entryRecordService.exitVehicle(dto));
     }
 
     // 📜 출입 기록 전체 조회

--- a/backend/src/main/java/com/ohammer/apartner/domain/vehicle/controller/VehicleController.java
+++ b/backend/src/main/java/com/ohammer/apartner/domain/vehicle/controller/VehicleController.java
@@ -95,6 +95,12 @@ public class VehicleController {
         );
     }
 
+    @GetMapping("/invited-approved")
+    public ResponseEntity<List<VehicleRegistrationInfoDto>> getInvitedApprovedVehicles() {
+        List<VehicleRegistrationInfoDto> approvedVehicles = vehicleService.getInvitedApprovedVehicles();
+        return ResponseEntity.ok(approvedVehicles);
+    }
+
 
 
 

--- a/backend/src/main/java/com/ohammer/apartner/domain/vehicle/controller/VehicleController.java
+++ b/backend/src/main/java/com/ohammer/apartner/domain/vehicle/controller/VehicleController.java
@@ -112,6 +112,15 @@ public class VehicleController {
         return ResponseEntity.ok(vehicleService.getParkingStatus());
     }
 
+    @GetMapping("/mine")
+    public ResponseEntity<List<VehicleRegistrationInfoDto>> getMyVehicles() {
+        List<VehicleRegistrationInfoDto> list = vehicleService.getMyVehicleRegistrations();
+        return ResponseEntity.ok(list);
+    }
+
+
+
+
 
 
 

--- a/backend/src/main/java/com/ohammer/apartner/domain/vehicle/controller/VehicleController.java
+++ b/backend/src/main/java/com/ohammer/apartner/domain/vehicle/controller/VehicleController.java
@@ -3,6 +3,7 @@ package com.ohammer.apartner.domain.vehicle.controller;
 
 import com.ohammer.apartner.domain.vehicle.dto.*;
 import com.ohammer.apartner.domain.vehicle.service.VehicleService;
+import com.ohammer.apartner.security.utils.SecurityUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -81,6 +82,20 @@ public class VehicleController {
         List<VehicleRegistrationInfoDto> approvedVehicles = vehicleService.getApprovedVehicles();
         return ResponseEntity.ok(approvedVehicles);
     }
+
+    @GetMapping("/visitors/pending")
+    public ResponseEntity<List<VehicleRegistrationInfoDto>> getMyRequests() {
+        Long inviterId = SecurityUtil.getCurrentUserId();
+        if (inviterId == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+        }
+
+        return ResponseEntity.ok(
+                vehicleService.getMyVisitorRequests(inviterId)
+        );
+    }
+
+
 
 
 

--- a/backend/src/main/java/com/ohammer/apartner/domain/vehicle/controller/VehicleController.java
+++ b/backend/src/main/java/com/ohammer/apartner/domain/vehicle/controller/VehicleController.java
@@ -107,6 +107,11 @@ public class VehicleController {
         return ResponseEntity.ok(list);
     }
 
+    @GetMapping("/status")
+    public ResponseEntity<ParkingStatusDto> getParkingStatus() {
+        return ResponseEntity.ok(vehicleService.getParkingStatus());
+    }
+
 
 
 

--- a/backend/src/main/java/com/ohammer/apartner/domain/vehicle/controller/VehicleController.java
+++ b/backend/src/main/java/com/ohammer/apartner/domain/vehicle/controller/VehicleController.java
@@ -101,6 +101,12 @@ public class VehicleController {
         return ResponseEntity.ok(approvedVehicles);
     }
 
+    @GetMapping("/active")
+    public ResponseEntity<List<VehicleRegistrationInfoDto>> getActiveVehicles() {
+        List<VehicleRegistrationInfoDto> list = vehicleService.getActiveVehicles();
+        return ResponseEntity.ok(list);
+    }
+
 
 
 

--- a/backend/src/main/java/com/ohammer/apartner/domain/vehicle/dto/ForeignVehicleRequestDto.java
+++ b/backend/src/main/java/com/ohammer/apartner/domain/vehicle/dto/ForeignVehicleRequestDto.java
@@ -9,7 +9,7 @@ public class ForeignVehicleRequestDto {
     private String type;
     private String phone;
     private String reason; // 외부 차량 사유: 예) 배달, 방문 등
-
+    private String apartmentName;  //
     private String buildingNum; // 입력받는 동
     private String unitNum;     // 입력받는 호수
 }

--- a/backend/src/main/java/com/ohammer/apartner/domain/vehicle/dto/ForeignVehicleRequestDto.java
+++ b/backend/src/main/java/com/ohammer/apartner/domain/vehicle/dto/ForeignVehicleRequestDto.java
@@ -9,4 +9,7 @@ public class ForeignVehicleRequestDto {
     private String type;
     private String phone;
     private String reason; // 외부 차량 사유: 예) 배달, 방문 등
+
+    private String buildingNum; // 입력받는 동
+    private String unitNum;     // 입력받는 호수
 }

--- a/backend/src/main/java/com/ohammer/apartner/domain/vehicle/dto/ParkingStatusDto.java
+++ b/backend/src/main/java/com/ohammer/apartner/domain/vehicle/dto/ParkingStatusDto.java
@@ -1,0 +1,14 @@
+package com.ohammer.apartner.domain.vehicle.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ParkingStatusDto {
+    private int totalCapacity;   // 총 주차 가능 수
+    private long activeCount;    // 현재 ACTIVE 차량 수
+    private int remainingSpace;  // 남은 자리 수
+}

--- a/backend/src/main/java/com/ohammer/apartner/domain/vehicle/dto/VehicleRegistrationInfoDto.java
+++ b/backend/src/main/java/com/ohammer/apartner/domain/vehicle/dto/VehicleRegistrationInfoDto.java
@@ -2,6 +2,7 @@ package com.ohammer.apartner.domain.vehicle.dto;
 
 
 
+import com.ohammer.apartner.domain.apartment.entity.Apartment;
 import com.ohammer.apartner.domain.user.entity.User;
 import com.ohammer.apartner.domain.vehicle.entity.EntryRecord;
 import com.ohammer.apartner.domain.vehicle.entity.Vehicle;
@@ -17,6 +18,7 @@ public class VehicleRegistrationInfoDto {
     private Long id; // 신청번호
     private String registerType; // 등록 구분 (거주자/방문자)
     private String applicantName; // 신청자 이름 또는 택배, 손님 등
+    private String apartmentName;
     private String buildingName; // 동
     private String unitName; // 호수
     private String vehicleNum; // 차량번호
@@ -35,6 +37,7 @@ public class VehicleRegistrationInfoDto {
 
         String registerType = isForeign ? "방문자" : "거주자";
         String applicantName;
+        String apartment = null;
         String building = null;
         String unit = null;
         String phone;
@@ -44,10 +47,13 @@ public class VehicleRegistrationInfoDto {
             phone = vehicle.getPhone();
         } else {
             User user = vehicle.getUser();
-            applicantName = user != null ? user.getUserName() : "미등록/탈퇴한 사용자";
+            applicantName = user != null ? user.getUserName() : "탈퇴한 사용자";
             building = user != null && user.getBuilding() != null ? user.getBuilding().getBuildingNumber() : null;
             unit = user != null && user.getUnit() != null ? user.getUnit().getUnitNumber() : null;
             phone = user != null ? user.getPhoneNum() : null;
+            // 여기에 apartmentName 세팅
+            Apartment apt = user != null ? user.getApartment() : null;  // 혹은 vehicle.getApartment()
+            apartment = apt != null ? apt.getName() : null;
 //            applicantName = String.valueOf(user.getId()); // 혹은 .toString()
 //            building = user.getBuilding().getBuildingNumber();
 //            unit = user.getUnit().getUnitNumber();
@@ -58,6 +64,7 @@ public class VehicleRegistrationInfoDto {
                 .id(vehicle.getId())
                 .registerType(registerType)
                 .applicantName(applicantName)
+                .apartmentName(apartment)
                 .buildingName(building)
                 .unitName(unit)
                 .vehicleNum(vehicle.getVehicleNum())

--- a/backend/src/main/java/com/ohammer/apartner/domain/vehicle/dto/VehicleRegistrationInfoDto.java
+++ b/backend/src/main/java/com/ohammer/apartner/domain/vehicle/dto/VehicleRegistrationInfoDto.java
@@ -25,7 +25,7 @@ public class VehicleRegistrationInfoDto {
     private String type; // 차종
     private String phone; // 연락처
     private LocalDateTime createdAt; // 신청일
-    private LocalDateTime visitPeriod; // 방문기간 (외부인일 경우만 사용)
+    //private LocalDateTime visitPeriod; // 방문기간 (외부인일 경우만 사용)
 
     private String reason;     // 외부 차량 방문 사유
     private String userPhone;  // 연락처 (거주자는 user에서, 외부인은 직접 입력)
@@ -42,22 +42,72 @@ public class VehicleRegistrationInfoDto {
         String unit = null;
         String phone;
 
+        LocalDateTime visitPeriod = null; // 외부인 방문기간이 없다면 null
+
+        User inviter = vehicle.getUser(); // 외부인은 여기에 “초청자(집주인)” 정보가 들어있음
+
+        User user = vehicle.getUser(); // null일 수 있음
+
         if (isForeign) {
             applicantName = vehicle.getReason(); // 예: 택배, 배달, 손님
             phone = vehicle.getPhone();
+
+            // **여기부터 추가**: “누구 집”에 방문했는지 보여주려면 inviter 정보로 세팅
+            if (inviter != null) {
+                Apartment apt = inviter.getApartment();
+                apartment = apt != null ? apt.getName() : null;
+                building  = inviter.getBuilding() != null
+                        ? inviter.getBuilding().getBuildingNumber() : null;
+                unit      = inviter.getUnit() != null
+                        ? inviter.getUnit().getUnitNumber() : null;
+            }
         } else {
-            User user = vehicle.getUser();
-            applicantName = user != null ? user.getUserName() : "탈퇴한 사용자";
-            building = user != null && user.getBuilding() != null ? user.getBuilding().getBuildingNumber() : null;
-            unit = user != null && user.getUnit() != null ? user.getUnit().getUnitNumber() : null;
-            phone = user != null ? user.getPhoneNum() : null;
-            // 여기에 apartmentName 세팅
-            Apartment apt = user != null ? user.getApartment() : null;  // 혹은 vehicle.getApartment()
-            apartment = apt != null ? apt.getName() : null;
+
+            // 거주자: user → applicantName, phone, apt/동/호수 채우기
+            applicantName  = inviter != null && inviter.getUserName() != null
+                    ? inviter.getUserName() : "탈퇴한 사용자";
+            phone          = inviter != null ? inviter.getPhoneNum() : null;
+            if (inviter != null) {
+                Apartment apt = inviter.getApartment();
+                apartment = apt != null ? apt.getName() : null;
+                building  = inviter.getBuilding() != null
+                        ? inviter.getBuilding().getBuildingNumber() : null;
+                unit = inviter.getUnit() != null
+                        ? inviter.getUnit().getUnitNumber() : null;
+
+
+//            applicantName = (user != null && user.getUserName() != null)
+//                    ? user.getUserName()
+//                    : "탈퇴한 사용자";
+//            phone = (user != null)
+//                    ? user.getPhoneNum()
+//                    : null;
+//            if (user != null) {
+//                apartment = user.getApartment() != null
+//                        ? user.getApartment().getName()
+//                        : null;
+//                building = user.getBuilding() != null
+//                        ? user.getBuilding().getBuildingNumber()
+//                        : null;
+//                unit = user.getUnit() != null
+//                        ? user.getUnit().getUnitNumber()
+//                        : null;
+
+//            User user = vehicle.getUser();
+//            applicantName = user != null ? user.getUserName() : "탈퇴한 사용자";
+//            building = user != null && user.getBuilding() != null ? user.getBuilding().getBuildingNumber() : null;
+//            unit = user != null && user.getUnit() != null ? user.getUnit().getUnitNumber() : null;
+//            phone = user != null ? user.getPhoneNum() : null;
+//            // 여기에 apartmentName 세팅
+//            Apartment apt = user != null ? user.getApartment() : null;  // 혹은 vehicle.getApartment()
+//            apartment = apt != null ? apt.getName() : null;
+
+
 //            applicantName = String.valueOf(user.getId()); // 혹은 .toString()
 //            building = user.getBuilding().getBuildingNumber();
 //            unit = user.getUnit().getUnitNumber();
 //            phone = user.getPhoneNum();
+            }
         }
 
         return VehicleRegistrationInfoDto.builder()
@@ -72,6 +122,10 @@ public class VehicleRegistrationInfoDto {
                 .phone(phone)
                 .createdAt(vehicle.getCreatedAt())
                 //.visitPeriod(vehicle.getVisitPeriod()) // visitPeriod 필드 Vehicle 엔티티에 있어야 함
+                //.visitPeriod(visitPeriod)
+                .reason(isForeign ? vehicle.getReason() : null)
+                //.userPhone(!isForeign ? phone : null)
+                .userPhone(phone) // ✅ 무조건 phone을 넣자
                 .status(entryRecord.getStatus() != null ? entryRecord.getStatus().name() : null) // ✅ 이 부분
                 .build();
     }

--- a/backend/src/main/java/com/ohammer/apartner/domain/vehicle/entity/EntryRecord.java
+++ b/backend/src/main/java/com/ohammer/apartner/domain/vehicle/entity/EntryRecord.java
@@ -1,5 +1,6 @@
 package com.ohammer.apartner.domain.vehicle.entity;
 
+import com.ohammer.apartner.domain.user.entity.User;
 import com.ohammer.apartner.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -34,4 +35,9 @@ public class EntryRecord extends BaseEntity {
     public enum Status {
         AGREE, INAGREE, PENDING
     }
+
+//    @ManyToOne(fetch = FetchType.LAZY, optional = true)
+//    @JoinColumn(name = "inviter_id")
+//    private User inviter;
+
 } 

--- a/backend/src/main/java/com/ohammer/apartner/domain/vehicle/entity/EntryRecord.java
+++ b/backend/src/main/java/com/ohammer/apartner/domain/vehicle/entity/EntryRecord.java
@@ -33,7 +33,7 @@ public class EntryRecord extends BaseEntity {
 
     // Enum for status
     public enum Status {
-        AGREE, INAGREE, PENDING
+        AGREE, INAGREE, PENDING, INVITER_AGREE
     }
 
 //    @ManyToOne(fetch = FetchType.LAZY, optional = true)

--- a/backend/src/main/java/com/ohammer/apartner/domain/vehicle/entity/Vehicle.java
+++ b/backend/src/main/java/com/ohammer/apartner/domain/vehicle/entity/Vehicle.java
@@ -4,6 +4,8 @@ import com.ohammer.apartner.domain.user.entity.User;
 import com.ohammer.apartner.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.NotFound;
+import org.hibernate.annotations.NotFoundAction;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -18,6 +20,7 @@ import java.util.List;
 public class Vehicle extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY, optional = true)
+    @NotFound(action = NotFoundAction.IGNORE)
     @JoinColumn(name = "user_id", nullable = true)
     private User user;
 

--- a/backend/src/main/java/com/ohammer/apartner/domain/vehicle/repository/VehicleRepository.java
+++ b/backend/src/main/java/com/ohammer/apartner/domain/vehicle/repository/VehicleRepository.java
@@ -50,7 +50,10 @@ public interface VehicleRepository extends JpaRepository<Vehicle, Long> {
 
 
 
-
+    /**
+     * status가 ACTIVE인 Vehicle만 조회
+     */
+    List<Vehicle> findAllByStatus(Vehicle.Status status);
 
 
 

--- a/backend/src/main/java/com/ohammer/apartner/domain/vehicle/repository/VehicleRepository.java
+++ b/backend/src/main/java/com/ohammer/apartner/domain/vehicle/repository/VehicleRepository.java
@@ -36,6 +36,13 @@ public interface VehicleRepository extends JpaRepository<Vehicle, Long> {
 
 
 
+    Optional<Vehicle> findByIdAndUser_Id(Long vehicleId, Long userId);
+
+    // 한 유저의 모든 차량을 가져오는 메서드
+    List<Vehicle> findAllByUser_Id(Long userId);
+
+
+
 
 
 

--- a/backend/src/main/java/com/ohammer/apartner/domain/vehicle/repository/VehicleRepository.java
+++ b/backend/src/main/java/com/ohammer/apartner/domain/vehicle/repository/VehicleRepository.java
@@ -55,6 +55,9 @@ public interface VehicleRepository extends JpaRepository<Vehicle, Long> {
      */
     List<Vehicle> findAllByStatus(Vehicle.Status status);
 
+    long countByStatus(Vehicle.Status status);
+
+
 
 
 

--- a/backend/src/main/java/com/ohammer/apartner/domain/vehicle/repository/VehicleRepository.java
+++ b/backend/src/main/java/com/ohammer/apartner/domain/vehicle/repository/VehicleRepository.java
@@ -1,7 +1,10 @@
 package com.ohammer.apartner.domain.vehicle.repository;
 
+import com.ohammer.apartner.domain.vehicle.entity.EntryRecord;
 import com.ohammer.apartner.domain.vehicle.entity.Vehicle;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -20,6 +23,17 @@ public interface VehicleRepository extends JpaRepository<Vehicle, Long> {
     // isForeign 값에 따라 필터링된 조회
 
     Optional<Vehicle> findByUser_Id(Long userId);
+
+    // 수정된 메소드
+    List<Vehicle> findByIsForeignTrueAndStatusAndUser_Id(Vehicle.Status status, Long userId);
+
+    @Query("SELECT v FROM Vehicle v JOIN EntryRecord e ON e.vehicle = v " +
+            "WHERE v.isForeign = true AND v.user.id = :inviterId AND e.status = :status")
+    List<Vehicle> findForeignVehiclesWithPendingEntryRecordByInviterId(
+            @Param("inviterId") Long inviterId,
+            @Param("status") EntryRecord.Status status
+    );
+
 
 
 

--- a/backend/src/main/java/com/ohammer/apartner/domain/vehicle/repository/VehicleRepository.java
+++ b/backend/src/main/java/com/ohammer/apartner/domain/vehicle/repository/VehicleRepository.java
@@ -41,6 +41,18 @@ public interface VehicleRepository extends JpaRepository<Vehicle, Long> {
     // 한 유저의 모든 차량을 가져오는 메서드
     List<Vehicle> findAllByUser_Id(Long userId);
 
+    Optional<Vehicle> findByPhoneAndIsForeign(String phone, Boolean isForeign);
+
+    // 외부인 차량 조회
+    Optional<Vehicle> findByPhoneAndIsForeign(String phone, boolean isForeign);
+
+    Optional<Vehicle> findTopByPhoneAndIsForeignOrderByCreatedAtDesc(String phone, boolean isForeign);
+
+
+
+
+
+
 
 
 

--- a/backend/src/main/java/com/ohammer/apartner/domain/vehicle/repository/VehicleRepository.java
+++ b/backend/src/main/java/com/ohammer/apartner/domain/vehicle/repository/VehicleRepository.java
@@ -57,6 +57,9 @@ public interface VehicleRepository extends JpaRepository<Vehicle, Long> {
 
     long countByStatus(Vehicle.Status status);
 
+    List<Vehicle> findByUserId(Long userId);
+
+
 
 
 

--- a/backend/src/main/java/com/ohammer/apartner/domain/vehicle/service/EntryRecordService.java
+++ b/backend/src/main/java/com/ohammer/apartner/domain/vehicle/service/EntryRecordService.java
@@ -51,17 +51,38 @@ public class EntryRecordService {
     }
 
 
+
+
     // 🚗 입차
     public EntryRecordResponseDto enterVehicle(EntryRecordRequestDto dto) {
-        //Vehicle vehicle = vehicleService.findById(dto.getVehicleId());
-        Vehicle vehicle = vehicleService.findByCurrentUser();
+//        //Vehicle vehicle = vehicleService.findById(dto.getVehicleId());
+//        Vehicle vehicle = vehicleService.findByCurrentUser();
+//
+//        // 1) 외부인이라면 제출된 전화번호 검증
+//        if (Boolean.TRUE.equals(vehicle.getIsForeign())) {
+//            String registeredPhone = vehicle.getPhone();
+//            if (dto.getPhone() == null || !registeredPhone.equals(dto.getPhone())) {
+//                throw new IllegalArgumentException("등록된 전화번호와 일치하지 않습니다.");
+//            }
+//        }
 
-        // 1) 외부인이라면 제출된 전화번호 검증
-        if (Boolean.TRUE.equals(vehicle.getIsForeign())) {
-            String registeredPhone = vehicle.getPhone();
-            if (dto.getPhone() == null || !registeredPhone.equals(dto.getPhone())) {
-                throw new IllegalArgumentException("등록된 전화번호와 일치하지 않습니다.");
-            }
+        Vehicle vehicle;
+
+        // ── 1) 외부인 분기 ───────────────────────────────────
+        // dto.getPhone()에 값이 있으면 외부인 입차
+        if (dto.getPhone() != null) {
+            // 차량 테이블에 isForeign = true, phone 칼럼으로 검색
+            vehicle = vehicleService
+                    //.findByPhoneAndIsForeign(dto.getPhone(), true)
+                    .findLatestByPhoneAndIsForeign(dto.getPhone())  // ← 이 부분을 변경
+                    .orElseThrow(() -> new IllegalArgumentException("등록된 외부 차량이 없습니다."));
+
+            // (전화번호 일치 검사는 findBy… 호출만으로 끝났으므로 추가 검사는 불필요)
+        }
+        // ── 2) 입주민 분기 ───────────────────────────────────
+        else {
+            // 기존처럼 로그인한 유저의 차량 한 대 가져오기
+            vehicle = vehicleService.findByCurrentUser();
         }
 
         // 가장 최근 승인된(AGREE) 출입기록 찾기, exitTime이 null인 상태
@@ -91,9 +112,22 @@ public class EntryRecordService {
 
     // 🚙 출차
     @Transactional
-    public EntryRecordResponseDto exitVehicle() {
+    public EntryRecordResponseDto exitVehicle(EntryRecordRequestDto dto) {
 
-        Vehicle vehicle = vehicleService.findByCurrentUser();
+        Vehicle vehicle;
+
+        // ── 1) 외부인 분기 ───────────────────────────────────
+        if (dto != null && dto.getPhone() != null) {
+            vehicle = vehicleService
+                    .findMostRecentActiveVehicleByPhoneAndIsForeign(dto.getPhone(), true)
+                    .orElseThrow(() -> new IllegalArgumentException("등록된 외부 차량이 없습니다."));
+        }
+        // ── 2) 입주민 분기 ───────────────────────────────────
+        else {
+            vehicle = vehicleService.findByCurrentUser();
+        }
+
+        //Vehicle vehicle = vehicleService.findByCurrentUser();
         // 승인된 출입기록 중 출차 안 한 기록 조회
         EntryRecord activeRecord = entryRecordRepository
                 .findFirstByVehicleIdAndStatusAndExitTimeIsNullOrderByEntryTimeDesc(
@@ -134,7 +168,7 @@ public class EntryRecordService {
 
         EntryRecord entryRecord = EntryRecord.builder()
                 .vehicle(vehicle)
-                .status(EntryRecord.Status.PENDING)
+                .status(EntryRecord.Status.AGREE)
                 .build();
 
         entryRecordRepository.save(entryRecord);
@@ -152,6 +186,8 @@ public class EntryRecordService {
         record.setStatus(newStatus);
         return new EntryRecordStatusDto(record.getId(), record.getStatus().name());
     }
+
+
 
 
 

--- a/backend/src/main/java/com/ohammer/apartner/domain/vehicle/service/EntryRecordService.java
+++ b/backend/src/main/java/com/ohammer/apartner/domain/vehicle/service/EntryRecordService.java
@@ -24,6 +24,7 @@ public class EntryRecordService {
 
     private final EntryRecordRepository entryRecordRepository;
     private final VehicleService vehicleService;
+    private static final int MAX_CAPACITY = 30; // 총 주차 가능 수
 
 //    @Transactional
 //    public EntryRecord updateStatus(Long entryRecordId, EntryRecord.Status newStatus) {
@@ -65,6 +66,17 @@ public class EntryRecordService {
 //                throw new IllegalArgumentException("등록된 전화번호와 일치하지 않습니다.");
 //            }
 //        }
+
+        long activeCount = vehicleService.countActiveVehicles();
+
+        if (activeCount >= MAX_CAPACITY) {
+            throw new IllegalStateException("주차장이 꽉 찼습니다.");
+        }
+
+
+
+
+
 
         Vehicle vehicle;
 

--- a/backend/src/main/java/com/ohammer/apartner/domain/vehicle/service/EntryRecordService.java
+++ b/backend/src/main/java/com/ohammer/apartner/domain/vehicle/service/EntryRecordService.java
@@ -9,6 +9,7 @@ import com.ohammer.apartner.domain.vehicle.entity.EntryRecord;
 import com.ohammer.apartner.domain.vehicle.entity.Vehicle;
 import com.ohammer.apartner.domain.vehicle.repository.EntryRecordRepository;
 //import jakarta.transaction.Transactional;
+import com.ohammer.apartner.security.utils.SecurityUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -46,6 +47,14 @@ public class EntryRecordService {
     public EntryRecordStatusDto updateStatus(Long entryRecordId, EntryRecord.Status newStatus) {
         EntryRecord record = entryRecordRepository.findById(entryRecordId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 출입기록이 없습니다."));
+
+        // 소유자 확인 (출입기록 → 차량 → 소유자)
+        Long currentUserId = SecurityUtil.getCurrentUserId();
+        if (!record.getVehicle().getUser().getId().equals(currentUserId)) {
+            throw new IllegalArgumentException("본인의 차량에 대한 요청만 처리할 수 있습니다.");
+        }
+
+
 
         record.setStatus(newStatus);
         return new EntryRecordStatusDto(record.getId(), record.getStatus().name());

--- a/backend/src/main/java/com/ohammer/apartner/domain/vehicle/service/VehicleService.java
+++ b/backend/src/main/java/com/ohammer/apartner/domain/vehicle/service/VehicleService.java
@@ -273,6 +273,17 @@ public class VehicleService {
                 .findTopByPhoneAndIsForeignOrderByCreatedAtDesc(phone, isForeign);
     }
 
+    @Transactional(readOnly = true)
+    public List<VehicleRegistrationInfoDto> getInvitedApprovedVehicles() {
+        List<EntryRecord> approvedRecords = entryRecordRepository.findByStatus(EntryRecord.Status.INVITER_AGREE);
+
+        return approvedRecords.stream()
+                .map(record -> VehicleRegistrationInfoDto.from(record.getVehicle(), record))
+                .collect(Collectors.toList());
+    }
+
+
+
 
 
 

--- a/backend/src/main/java/com/ohammer/apartner/domain/vehicle/service/VehicleService.java
+++ b/backend/src/main/java/com/ohammer/apartner/domain/vehicle/service/VehicleService.java
@@ -28,14 +28,19 @@ public class VehicleService {
     private final VehicleRepository vehicleRepository;
     private final UserRepository userRepository;
     private final EntryRecordRepository entryRecordRepository;
+    private static final int MAX_CAPACITY = 30; // 총 주차 가능 수
 
     // 입주민 차량 등록
     @Transactional
     public VehicleResponseDto registerResidentVehicle(ResidentVehicleRequestDto dto) {
+
+
 //        User user = userRepository.findById(dto.getUserId())
 //                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
 
         // 1) SecurityUtil로 현재 로그인한 User 엔티티를 바로 꺼낸다.
+
+
         User currentUser = SecurityUtil.getCurrentUser();
         if (currentUser == null) {
             throw new IllegalStateException("로그인된 사용자가 아닙니다.");
@@ -73,6 +78,13 @@ public class VehicleService {
     // 외부 차량 등록
     @Transactional
     public VehicleResponseDto registerForeignVehicle(ForeignVehicleRequestDto dto) {
+
+//        long activeCount = vehicleRepository.countByStatus(Vehicle.Status.ACTIVE);
+//
+//        if (activeCount >= 17) {
+//            throw new IllegalStateException("주차장이 꽉 찼습니다.");
+//        }
+
 
         // ✅ 1. 동/호수로 입주민(User) 조회
         User inviter = userRepository.findByAptAndBuildingAndUnit(
@@ -294,6 +306,29 @@ public class VehicleService {
                         EntryRecord.builder().status(null).build()))
                 .collect(Collectors.toList());
     }
+
+    // 현재 주차 중인 차량 수
+    public long countActiveVehicles() {
+        return vehicleRepository.countByStatus(Vehicle.Status.ACTIVE);
+    }
+
+    // 남은 주차 공간 수
+    public int getRemainingSpace() {
+        long activeCount = countActiveVehicles();
+        return MAX_CAPACITY - (int) activeCount;
+    }
+
+    // 전체 주차장 현황 반환 DTO
+    public ParkingStatusDto getParkingStatus() {
+        long activeCount = countActiveVehicles();
+        return ParkingStatusDto.builder()
+                .totalCapacity(MAX_CAPACITY)
+                .activeCount(activeCount)
+                .remainingSpace(MAX_CAPACITY - (int) activeCount)
+                .build();
+    }
+
+
 
 
 

--- a/backend/src/main/java/com/ohammer/apartner/domain/vehicle/service/VehicleService.java
+++ b/backend/src/main/java/com/ohammer/apartner/domain/vehicle/service/VehicleService.java
@@ -282,6 +282,19 @@ public class VehicleService {
                 .collect(Collectors.toList());
     }
 
+    @Transactional(readOnly = true)
+    public List<VehicleRegistrationInfoDto> getActiveVehicles() {
+        // 1) ACTIVE 차량 엔티티 조회
+        List<Vehicle> activeVehicles = vehicleRepository.findAllByStatus(Vehicle.Status.ACTIVE);
+
+        // 2) 필요한 DTO로 변환
+        return activeVehicles.stream()
+                .map(v -> VehicleRegistrationInfoDto.from(v,
+                        /* 여기 EntryRecord는 필요 없으면 더미나 null 처리 */
+                        EntryRecord.builder().status(null).build()))
+                .collect(Collectors.toList());
+    }
+
 
 
 

--- a/backend/src/main/java/com/ohammer/apartner/domain/vehicle/service/VehicleService.java
+++ b/backend/src/main/java/com/ohammer/apartner/domain/vehicle/service/VehicleService.java
@@ -186,6 +186,12 @@ public class VehicleService {
         Vehicle vehicle = vehicleRepository.findById(vehicleId)
                 .orElseThrow(() -> new RuntimeException("차량을 찾을 수 없습니다."));
 
+        // 2) 소유자 확인
+        Long currentUserId = SecurityUtil.getCurrentUserId();
+        if (!vehicle.getUser().getId().equals(currentUserId)) {
+            throw new IllegalArgumentException("본인의 차량만 수정할 수 있습니다.");
+        }
+
         vehicle.setVehicleNum(dto.getVehicleNum());
         vehicle.setType(dto.getType());
     }
@@ -195,6 +201,12 @@ public class VehicleService {
         // 차량을 찾을 수 없으면 예외 발생
         Vehicle vehicle = vehicleRepository.findById(vehicleId)
                 .orElseThrow(() -> new RuntimeException("차량을 찾을 수 없습니다."));
+
+        // 소유자 확인
+        Long currentUserId = SecurityUtil.getCurrentUserId();
+        if (!vehicle.getUser().getId().equals(currentUserId)) {
+            throw new IllegalArgumentException("본인의 차량만 삭제할 수 있습니다.");
+        }
 
         // 차량 삭제
         entryRecordRepository.deleteAllByVehicle(vehicle);

--- a/backend/src/main/java/com/ohammer/apartner/domain/vehicle/service/VehicleService.java
+++ b/backend/src/main/java/com/ohammer/apartner/domain/vehicle/service/VehicleService.java
@@ -55,7 +55,7 @@ public class VehicleService {
         // EntryRecord 생성
         EntryRecord entryRecord = EntryRecord.builder()
                 .vehicle(vehicle)
-                .status(EntryRecord.Status.PENDING)
+                .status(EntryRecord.Status.AGREE)
                 .build();
 
 

--- a/backend/src/main/java/com/ohammer/apartner/domain/vehicle/service/VehicleService.java
+++ b/backend/src/main/java/com/ohammer/apartner/domain/vehicle/service/VehicleService.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Service;
 
 
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 
 @Service
@@ -70,6 +71,12 @@ public class VehicleService {
     // 외부 차량 등록
     @Transactional
     public VehicleResponseDto registerForeignVehicle(ForeignVehicleRequestDto dto) {
+
+        // ✅ 1. 동/호수로 입주민(User) 조회
+        User inviter = userRepository.findByBuilding_BuildingNumberAndUnit_UnitNumber(
+                dto.getBuildingNum(), dto.getUnitNum()
+        ).orElseThrow(() -> new NoSuchElementException("해당 동/호수의 입주민이 존재하지 않습니다."));
+
         Vehicle vehicle = Vehicle.builder()
                 .vehicleNum(dto.getVehicleNum())
                 .type(dto.getType())
@@ -145,6 +152,7 @@ public class VehicleService {
                     .vehicleNum(vehicle.getVehicleNum())
                     .type(vehicle.getType())
                     .userPhone(user.getPhoneNum()) // 거주자일 경우 phone은 user에서 가져옴
+                    .apartmentName(user.getApartment().getName())
                     .buildingName(user.getBuilding().getBuildingNumber())
                     .unitName(user.getUnit().getUnitNumber())
                     .build();

--- a/backend/src/main/java/com/ohammer/apartner/domain/vehicle/service/VehicleService.java
+++ b/backend/src/main/java/com/ohammer/apartner/domain/vehicle/service/VehicleService.java
@@ -18,6 +18,7 @@ import org.springframework.stereotype.Service;
 import java.util.Comparator;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
@@ -257,6 +258,24 @@ public class VehicleService {
         return vehicleRepository.findByIdAndUser_Id(vehicleId, userId)
                 .orElseThrow(() -> new IllegalArgumentException("당신의 차량이 아니거나 존재하지 않습니다."));
     }
+
+
+    public Optional<Vehicle> findByPhoneAndIsForeign(String phone, Boolean isForeign) {
+        return vehicleRepository.findByPhoneAndIsForeign(phone, isForeign);
+    }
+
+    public Optional<Vehicle> findLatestByPhoneAndIsForeign(String phone) {
+        return vehicleRepository.findTopByPhoneAndIsForeignOrderByCreatedAtDesc(phone, true);
+    }
+
+    public Optional<Vehicle> findMostRecentActiveVehicleByPhoneAndIsForeign(String phone, boolean isForeign) {
+        return vehicleRepository
+                .findTopByPhoneAndIsForeignOrderByCreatedAtDesc(phone, isForeign);
+    }
+
+
+
+
 
 
 

--- a/backend/src/main/java/com/ohammer/apartner/security/config/SecurityConfig.java
+++ b/backend/src/main/java/com/ohammer/apartner/security/config/SecurityConfig.java
@@ -63,8 +63,10 @@ public class SecurityConfig {
                                 //암시로 넣어야징
                                 "/api/v1/inspection/**",
                                 "/api/v1/admin/register", "/api/v1/admin/check", "/api/v1/sms/**",
-                                "/api/v1/vehicles/**",
+                                "/api/v1/vehicles/foreigns",
                                 "/api/v1/entry-records/**"
+
+
 
                         ).permitAll()
                         // 관리자 전용 API

--- a/backend/src/main/java/com/ohammer/apartner/security/config/SecurityConfig.java
+++ b/backend/src/main/java/com/ohammer/apartner/security/config/SecurityConfig.java
@@ -64,7 +64,8 @@ public class SecurityConfig {
                                 "/api/v1/inspection/**",
                                 "/api/v1/admin/register", "/api/v1/admin/check", "/api/v1/sms/**",
                                 "/api/v1/vehicles/foreigns",
-                                "/api/v1/entry-records/**"
+                                "/api/v1/entry-records/enter",
+                                "/api/v1/entry-records/exit"
 
 
 

--- a/backend/src/main/java/com/ohammer/apartner/security/jwt/JwtAuthFilter.java
+++ b/backend/src/main/java/com/ohammer/apartner/security/jwt/JwtAuthFilter.java
@@ -50,7 +50,9 @@ public class JwtAuthFilter extends OncePerRequestFilter {
             requestURI.contains("/signup") ||  // 회원가입 페이지 제외
             requestURI.contains("/login") ||  // 로그인 페이지 제외
             requestURI.startsWith("/oauth2/") ||  // OAuth2 인증 시작점 제외
-            requestURI.startsWith("/login/oauth2/")) {  // OAuth2 콜백 제외
+            requestURI.startsWith("/login/oauth2/") ||  // 로그인 페이지 제외
+            requestURI.startsWith("/api/v1/entry-records/enter") ||  //
+            requestURI.startsWith("/api/v1/entry-records/exit")) {  //
             log.info("[JwtAuthFilter] Skipping authentication for public endpoint: {}", requestURI);
             filterChain.doFilter(request, response);
             return;


### PR DESCRIPTION

기존 : 입주민, 외부인 둘 다 주차 차량 등록 -> 관리자가 허용 시 주차구역 출입 동작 가능
수정 : 입주민은 주차 차량 등록 시 바로 승인받고 외부인이 등록 시 용건 있는 아파트, 동, 호수와 용건내용, 연락처 등을 
입력하고 해당 아파트, 동, 호수에 거주하는 입주민이 해당 등록을 조회하고 승인하면 관리자가 그걸 보고 최종 승인하는 흐름, 외부인은 주차 차량 등록 시 입력했던 연락처를 토대로 주차장 출입시 본인인증을 진행하는걸로

주차 승인을 받은 입주민의 출입 기록 입차 출차 시 상태 변경

기존 로직에서 유저아이디 입력 -> 현재 로그인 된 유저 정보 불러오게 하는걸로 수정

차 등록 정보 상태랑 조회할떄 아파트 이름도 같이 들어가도록 수정

입주민 계정 앞 소유 차량 등록 여러개 허용하는걸로 수정

입주자에게는 허가 받았지만 관리자에게는 아직 허가받지 않은 차량 주차 등록 조회

현재 주차장에 주차중인 차량 리스트 조회와 현재 주차장 수용차량 한도와 현재 주차된 차량, 그리고 남은 주차공간 조회하고 초과 시 에러 처리

유저가 자신이 등록한 차량 목록 조회

자신이 계정으로 등록하지 않은 값에 대한 접근 예외 처리

