### PR TITLE
Feat/#41 점검 백엔드 마무리

### DIFF
--- a/backend/src/main/java/com/ohammer/apartner/domain/complaint/service/ComplaintService.java
+++ b/backend/src/main/java/com/ohammer/apartner/domain/complaint/service/ComplaintService.java
@@ -68,7 +68,7 @@ public class ComplaintService {
         Set<Role> userRoles = user.getRoles();
 
         boolean hasRequiredRole = userRoles.stream()
-                .anyMatch(role -> role == Role.ADMIN || role == Role.MODERATOR);
+                .anyMatch(role -> role == Role.ADMIN || role == Role.MANAGER);
 
         if (!hasRequiredRole) {
             throw new AccessDeniedException("전체 민원 목록을 조회할 권한이 없습니다.");

--- a/backend/src/main/java/com/ohammer/apartner/domain/complaint/service/ComplaintService.java
+++ b/backend/src/main/java/com/ohammer/apartner/domain/complaint/service/ComplaintService.java
@@ -105,7 +105,7 @@ public class ComplaintService {
         Set<Role> userRoles = user.getRoles();
 
         boolean hasRequiredRole = userRoles.stream()
-                .anyMatch(role -> role == Role.ADMIN || role == Role.MODERATOR);
+                .anyMatch(role -> role == Role.ADMIN || role == Role.MANAGER);
 
         if (!hasRequiredRole) {
             throw new AccessDeniedException("전체 민원 목록을 조회할 권한이 없습니다.");

--- a/backend/src/main/java/com/ohammer/apartner/domain/inspection/controller/InspectionIssueV1Controller.java
+++ b/backend/src/main/java/com/ohammer/apartner/domain/inspection/controller/InspectionIssueV1Controller.java
@@ -4,6 +4,7 @@ import com.ohammer.apartner.domain.inspection.dto.InspectionIssueDto;
 import com.ohammer.apartner.domain.inspection.dto.IssueResponseDetailDto;
 import com.ohammer.apartner.domain.inspection.entity.InspectionIssue;
 import com.ohammer.apartner.domain.inspection.service.InspectionIssueService;
+import com.ohammer.apartner.domain.inspection.service.InspectionService;
 import com.ohammer.apartner.security.CustomUserDetailsService;
 import com.ohammer.apartner.security.OAuth.CustomRequest;
 import com.ohammer.apartner.security.jwt.JwtTokenizer;
@@ -21,6 +22,7 @@ import org.springframework.web.bind.annotation.*;
 @Tag(name = "점검 이슈 api", description = "점검 이슈 API")
 public class InspectionIssueV1Controller {
     private final InspectionIssueService inspectionIssueService;
+    private final InspectionService inspectionService;
 
     //이슈 생성
     @PostMapping("{id}/create")
@@ -31,9 +33,8 @@ public class InspectionIssueV1Controller {
     public ResponseEntity<?> makeInspectionIssue(@PathVariable(name = "id")Long id,
                                                  @RequestBody InspectionIssueDto dto) {
         try {
-
-
             inspectionIssueService.makeInspectionIssue(id, dto.getDescription());
+            inspectionService.IssueInspection(id);
             return ResponseEntity.ok().build();
         } catch (Exception e) {
             return ResponseEntity.badRequest().body("이슈 생성 실패");

--- a/backend/src/main/java/com/ohammer/apartner/domain/inspection/controller/InspectionTypeV1Controller.java
+++ b/backend/src/main/java/com/ohammer/apartner/domain/inspection/controller/InspectionTypeV1Controller.java
@@ -34,20 +34,29 @@ public class InspectionTypeV1Controller {
         return ResponseEntity.ok().body(inspectionService.showAllTypes());
     }
 
-    @DeleteMapping("/{id}")
-    @Operation(
-            summary = "점검 항목을 삭제하기",
-            description = "삭제할 점검항목을 선택하여 삭제합니다"
-    )
-    public ResponseEntity<?> deleteType(@PathVariable(name = "id") Long id) {
-        try {
-            inspectionService.removeType(id);
-        }
-        catch (Exception e) {
-            return ResponseEntity.badRequest().body("삭제 실패했는뎁쇼");
-        }
-         return ResponseEntity.ok().build();
-    }
+    //일단은 보류
+//    @DeleteMapping("/{id}")
+//    @Operation(
+//            summary = "점검 항목을 삭제하기",
+//            description = "삭제할 점검항목을 선택하여 삭제합니다"
+//    )
+//    public ResponseEntity<?> deleteType(@PathVariable(name = "id") Long id) {
+//        try {
+//            inspectionService.removeType(id);
+//        }
+//        catch (Exception e) {
+//            return ResponseEntity.badRequest().body("삭제 실패했는뎁쇼");
+//        }
+//         return ResponseEntity.ok().build();
+//    }
+//
+//    @PostMapping("/{id}")
+//    @Operation(
+//            summary = "점검 항목을 수정하기",
+//            description = "점검항목을 선택하여 수정합니다, 그런데 쓸 일이 있을까요"
+//    ) public ResponseEntity<?> updateType(@PathVariable(name = "id") Long id) {
+//
+//    }
 
     @PostMapping("")
     @Operation(

--- a/backend/src/main/java/com/ohammer/apartner/domain/inspection/controller/InspectionV1Controller.java
+++ b/backend/src/main/java/com/ohammer/apartner/domain/inspection/controller/InspectionV1Controller.java
@@ -20,13 +20,60 @@ import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/inspection")
+@RequestMapping("/api/v1/inspection/manager")
 @Tag(name = "점검 api", description = "점검 API(일단은 메니저 전용)")
 public class InspectionV1Controller {
     private final InspectionService inspectionService;
-    //얼추 여기서 CRUD 넣기
-    //전체 불러오기
 
+
+    //추가
+    @PostMapping("/create")
+    @Operation(
+            summary = "점검 일정을 추가합니다, 점검 하는 사람은 로그인한 정보에서 뺴올 예정입니다",
+            description = "점검 일정을 추가합니다, 시작 및 종료 시간, 점검 항목, 점검내용을 넣습니다"
+    )
+    public ResponseEntity<Inspection> createInspectionSchedule(@RequestBody InspectionRequestDto dto) {
+        try{
+            inspectionService.newInspectionSchedule(dto);
+            return ResponseEntity.ok().build();
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().build();
+        }
+    }
+
+    //수정
+    @PostMapping("/{id}")
+    @Operation(
+            summary = "점검 일정을 변경합니다",
+            description = "점검 일정 내용을 변경합니다"
+    )
+    public ResponseEntity<?> updateInspectionSchedule(@PathVariable("id") Long id, @RequestBody InspectionUpdateDto dto) {
+        try {
+            inspectionService.updateInspection(id, dto);
+        } catch (Exception e) {
+            return ResponseEntity.notFound().build();
+        }
+
+        return ResponseEntity.ok().build();
+    }
+
+    //완료
+    @PostMapping("/complete/{id}")
+    @Operation(
+            summary = "점검 일정을 소화하고 완료 버튼을 누르면 해당 api가 쏴져서 DB에 저 일정은 완료되었다고 처리가 됩니다",
+            description = "해당 점검의 결과가 CHECKED로 변합니다"
+    )
+    public ResponseEntity<?> compeleteInspection(@PathVariable(name = "id") Long id) {
+        try {
+            inspectionService.completeInspection(id);
+            return ResponseEntity.ok().build();
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().build();
+        }
+    }
+
+
+    //전체 불러오기
     //그냥 여기서 제목만 불러와도 되는게 아닌가
     //TODO 매니저랑 유저에 대한 컨트롤러 각각 나누기
     @GetMapping("")
@@ -52,48 +99,6 @@ public class InspectionV1Controller {
             return ResponseEntity.badRequest().build();
         }
 
-    }
-
-
-    //추가
-    @PostMapping("/create")
-    @Operation(
-            summary = "점검 일정을 추가합니다, 점검 하는 사람은 로그인한 정보에서 뺴올 예정입니다",
-            description = "점검 일정을 추가합니다, 시작 및 종료 시간, 점검 항목, 점검내용을 넣습니다"
-    )
-    public ResponseEntity<Inspection> createInspectionSchedule(@RequestBody InspectionRequestDto dto) {
-        return ResponseEntity.ok(inspectionService.newInspectionSchedule(dto));
-    }
-
-    //수정
-    @PostMapping("/{id}")
-    @Operation(
-            summary = "점검 일정을 변경합니다",
-            description = "점검 일정 내용을 변경합니다"
-    )
-    public ResponseEntity<?> updateInspectionSchedule(@PathVariable("id") Long id, @RequestBody InspectionUpdateDto dto) {
-        try {
-            inspectionService.updateInspection(id, dto);
-        } catch (Exception e) {
-            return ResponseEntity.notFound().build();
-        }
-
-        return ResponseEntity.ok().build();
-    }
-
-    //완료
-    @PostMapping("/complete/{id}")
-    @Operation(
-          summary = "점검 일정을 소화하고 완료 버튼을 누르면 해당 api가 쏴져서 DB에 저 일정은 완료되었다고 처리가 됩니다",
-            description = "해당 점검의 결과가 CHECKED로 변합니다"
-    )
-    public ResponseEntity<?> compeleteInspection(@PathVariable(name = "id") Long id) {
-        try {
-            inspectionService.completeInspection(id);
-        return ResponseEntity.ok().build();
-        } catch (Exception e) {
-            return ResponseEntity.badRequest().build();
-        }
     }
 
     //제거

--- a/backend/src/main/java/com/ohammer/apartner/domain/inspection/controller/InspectionV1UserController.java
+++ b/backend/src/main/java/com/ohammer/apartner/domain/inspection/controller/InspectionV1UserController.java
@@ -1,8 +1,63 @@
 package com.ohammer.apartner.domain.inspection.controller;
 
-import org.springframework.web.bind.annotation.RestController;
+import com.ohammer.apartner.domain.inspection.dto.InspectionRequestDto;
+import com.ohammer.apartner.domain.inspection.dto.InspectionResponseDetailDto;
+import com.ohammer.apartner.domain.inspection.service.InspectionService;
+import com.ohammer.apartner.domain.inspection.service.InspectionUserService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 //이거는 유저용
 @RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/vi/inspection/user")
 public class InspectionV1UserController {
+    private final InspectionService inspectionService;
+    private final InspectionUserService inspectionUserService;
+    //자가 점검
+
+    //그런데 메니저의 그것고 차이는 뭐지?
+    //일단 조회할때 자기 것만 나와야지
+    @GetMapping("")
+    @Operation(
+            summary = "유저가 점검목록을 가져옵니다",
+            description = "점검 목록을 가져옵니다, 자기가 쓴 것이랑, 매니저가 쓴 것들이 나옵니다 주호야 페이징 처리해라"
+    )
+    public ResponseEntity<List<InspectionResponseDetailDto>>  showAllInspectionsWithUser() {
+        return ResponseEntity.ok(inspectionUserService.getAllInspectionWithUser());
+    }
+
+
+    //그리고 점검 등록할떄 공지에 안나가는 등록
+    @PostMapping("/create")
+    @Operation(
+            summary = "유저가 자가점검을 만듬니다",
+            description = "자가 점금을 만드는데 "
+    )
+    public ResponseEntity<?>createNewUserInspection(@RequestParam InspectionRequestDto dto) {
+        try {
+            inspectionUserService.newUserInspectionSchedule(dto);
+            return ResponseEntity.ok().build();
+        } catch (Exception e) {
+            return ResponseEntity.badRequest().build();
+        }
+    }
+
+
+    //그럼 누가 유저고, 매니저냐?
+    //구별법은
+        //시큐리티에서 role를 지정??
+        //
+
+    //수정 삭제도 본인 아니면 나가리 시켜야 하니까 해줘야지
+    //수정도 해줘야지
+
+
+    //삭제도
+
+
 }

--- a/backend/src/main/java/com/ohammer/apartner/domain/inspection/controller/InspectionV1UserController.java
+++ b/backend/src/main/java/com/ohammer/apartner/domain/inspection/controller/InspectionV1UserController.java
@@ -24,6 +24,7 @@ public class InspectionV1UserController {
     //자가 점검
 
     //그런데 메니저의 그것고 차이는 뭐지?
+
     //일단 조회할때 자기 것만 나와야지
     @GetMapping("")
     @Operation(
@@ -76,8 +77,4 @@ public class InspectionV1UserController {
         inspectionUserService.deleteUserInspection(id);
         return ResponseEntity.ok().build();
     }
-    //그럼 누가 유저고, 매니저냐?
-    //구별법은
-        //시큐리티에서 role를 지정??
-        //
 }

--- a/backend/src/main/java/com/ohammer/apartner/domain/inspection/controller/InspectionV1UserController.java
+++ b/backend/src/main/java/com/ohammer/apartner/domain/inspection/controller/InspectionV1UserController.java
@@ -2,9 +2,11 @@ package com.ohammer.apartner.domain.inspection.controller;
 
 import com.ohammer.apartner.domain.inspection.dto.InspectionRequestDto;
 import com.ohammer.apartner.domain.inspection.dto.InspectionResponseDetailDto;
+import com.ohammer.apartner.domain.inspection.dto.InspectionUpdateDto;
 import com.ohammer.apartner.domain.inspection.service.InspectionService;
 import com.ohammer.apartner.domain.inspection.service.InspectionUserService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -15,6 +17,7 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/vi/inspection/user")
+@Tag(name = "점검 유저 api", description = "점검 유저 API")
 public class InspectionV1UserController {
     private final InspectionService inspectionService;
     private final InspectionUserService inspectionUserService;
@@ -47,17 +50,34 @@ public class InspectionV1UserController {
         }
     }
 
+    //수정
+    @PostMapping("/{id}")
+    @Operation(
+            summary = "점검 일정을 변경합니다",
+            description = "점검 일정 내용을 변경합니다"
+    )
+    public ResponseEntity<?> updateInspectionUserSchedule(@PathVariable("id") Long id, @RequestBody InspectionUpdateDto dto) {
+        try {
+            inspectionUserService.updateInspectionUser(id, dto);
+        } catch (Exception e) {
+            return ResponseEntity.notFound().build();
+        }
 
+        return ResponseEntity.ok().build();
+    }
+
+    //제거
+    @DeleteMapping("/{id}")
+    @Operation(
+            summary = "해당 점검 내용을 지우고 싶을때 사용합니다, 그런데 지울 일이 있을까요?",
+            description = "해당 점검 일정을 삭제합니다"
+    )
+    public ResponseEntity<?> deleteInspectionUserSchedule(@PathVariable("id") Long id) {
+        inspectionUserService.deleteUserInspection(id);
+        return ResponseEntity.ok().build();
+    }
     //그럼 누가 유저고, 매니저냐?
     //구별법은
         //시큐리티에서 role를 지정??
         //
-
-    //수정 삭제도 본인 아니면 나가리 시켜야 하니까 해줘야지
-    //수정도 해줘야지
-
-
-    //삭제도
-
-
 }

--- a/backend/src/main/java/com/ohammer/apartner/domain/inspection/entity/Inspection.java
+++ b/backend/src/main/java/com/ohammer/apartner/domain/inspection/entity/Inspection.java
@@ -2,6 +2,7 @@ package com.ohammer.apartner.domain.inspection.entity;
 
 import com.ohammer.apartner.domain.opinion.entity.Opinion;
 import com.ohammer.apartner.domain.user.entity.User;
+import com.ohammer.apartner.global.Status;
 import com.ohammer.apartner.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -40,5 +41,9 @@ public class Inspection extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(name = "result")
     private Result result;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status")
+    private Status status;
 
 } 

--- a/backend/src/main/java/com/ohammer/apartner/domain/inspection/repository/InspectionRepository.java
+++ b/backend/src/main/java/com/ohammer/apartner/domain/inspection/repository/InspectionRepository.java
@@ -1,8 +1,21 @@
 package com.ohammer.apartner.domain.inspection.repository;
 
 import com.ohammer.apartner.domain.inspection.entity.Inspection;
+import com.ohammer.apartner.domain.user.entity.Role;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface InspectionRepository extends JpaRepository<Inspection, Long> {
     boolean existsById(Long id);
+
+//    @Query("SELECT i FROM Inspection i " +
+//            "JOIN i.user u " +
+//            "WHERE u.id = :userId OR u.roles = 'MODERATOR'")
+    @Query("SELECT i FROM Inspection i " +
+            "JOIN i.user u " +
+            "WHERE u.id = :userId OR :role MEMBER OF u.roles")
+    List<Inspection> findByUserIdOrManager(@Param("userId") Long userId, @Param("role")Role role);
 }

--- a/backend/src/main/java/com/ohammer/apartner/domain/inspection/repository/InspectionRepository.java
+++ b/backend/src/main/java/com/ohammer/apartner/domain/inspection/repository/InspectionRepository.java
@@ -14,8 +14,19 @@ public interface InspectionRepository extends JpaRepository<Inspection, Long> {
 //    @Query("SELECT i FROM Inspection i " +
 //            "JOIN i.user u " +
 //            "WHERE u.id = :userId OR u.roles = 'MODERATOR'")
-    @Query("SELECT i FROM Inspection i " +
+//    @Query("SELECT i FROM Inspection i " +
+//            "JOIN i.user u " +
+//            "WHERE u.id = :userId OR :role MEMBER OF u.roles")
+    @Query("SELECT DISTINCT i FROM Inspection i " +
             "JOIN i.user u " +
-            "WHERE u.id = :userId OR :role MEMBER OF u.roles")
-    List<Inspection> findByUserIdOrManager(@Param("userId") Long userId, @Param("role")Role role);
+            "JOIN u.roles r " +
+            "WHERE u.id = :userId OR r = :role")
+    List<Inspection> findByUserIdOrManager(@Param("userId") Long userId, @Param("role") Role role);
+
+
+    @Query("SELECT i FROM Inspection i WHERE i.user.id = :userId")
+    List<Inspection> findByUserId(@Param("userId") Long userId);
+
+    @Query("SELECT i FROM Inspection i JOIN i.user u JOIN u.roles r WHERE r = :role")
+    List<Inspection> findByRole(@Param("role") Role role);
 }

--- a/backend/src/main/java/com/ohammer/apartner/domain/inspection/service/InspectionIssueService.java
+++ b/backend/src/main/java/com/ohammer/apartner/domain/inspection/service/InspectionIssueService.java
@@ -3,6 +3,7 @@ package com.ohammer.apartner.domain.inspection.service;
 import com.ohammer.apartner.domain.inspection.dto.IssueResponseDetailDto;
 import com.ohammer.apartner.domain.inspection.entity.Inspection;
 import com.ohammer.apartner.domain.inspection.entity.InspectionIssue;
+import com.ohammer.apartner.domain.inspection.entity.Result;
 import com.ohammer.apartner.domain.inspection.repository.InspectionIssueRepository;
 import com.ohammer.apartner.domain.inspection.repository.InspectionRepository;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +24,7 @@ public class InspectionIssueService {
     @Transactional
     public InspectionIssue makeInspectionIssue(Long id, String description) {
         Inspection inspection = inspectionRepository.findById(id).orElseThrow();
+        inspection.setResult(Result.ISSUE);
 
         InspectionIssue inspectionIssue = InspectionIssue.builder()
                 .inspection(inspection)
@@ -33,6 +35,7 @@ public class InspectionIssueService {
                 .build();
 
         inspectionService.IssueInspection(id);
+        inspectionRepository.save(inspection);
         return issueRepository.save(inspectionIssue);
     }
 

--- a/backend/src/main/java/com/ohammer/apartner/domain/inspection/service/InspectionService.java
+++ b/backend/src/main/java/com/ohammer/apartner/domain/inspection/service/InspectionService.java
@@ -10,6 +10,7 @@ import com.ohammer.apartner.domain.inspection.repository.InspectionRepository;
 import com.ohammer.apartner.domain.inspection.repository.InspectionTypeRepository;
 import com.ohammer.apartner.domain.user.entity.User;
 import com.ohammer.apartner.domain.user.repository.UserRepository;
+import com.ohammer.apartner.global.Status;
 import com.ohammer.apartner.security.CustomUserDetailsService;
 import com.ohammer.apartner.security.utils.SecurityUtil;
 import lombok.RequiredArgsConstructor;
@@ -51,7 +52,7 @@ public class InspectionService {
         //원래 통으로 객체를 찾을까 싶었는데, 도용?의 문제가 있을 것 같아서 효율성 깎고 id뽑아서 찾아오는걸루
         Long userId = SecurityUtil.getOptionalCurrentUserId().orElseThrow();
 
-        User user = userRepository.findById(userId).orElseThrow();
+        User user = userRepository.findById(userId).get();
 
         InspectionType type = inspectionTypeRepository.findByTypeName(dto.getType());
 
@@ -65,7 +66,9 @@ public class InspectionService {
                 .result(Result.PENDING)
                 .modifiedAt(null)
                 .createdAt(LocalDateTime.now())
+                .status(Status.ACTIVE)
                 .build();
+        //TODO 나중에 공지 추가되면 공지에 넣는것도 추가하기
         return inspectionRepository.save(inspection);
     }
 
@@ -108,7 +111,10 @@ public class InspectionService {
     //삭제
     @Transactional
     public void deleteInspection(Long id) {
-        inspectionRepository.deleteById(id);
+        Inspection inspection = inspectionRepository.findById(id).orElseThrow();
+        inspection.setStatus(Status.WITHDRAWN);
+        inspectionRepository.save(inspection);
+        //inspectionRepository.deleteById(id);
     }
 
 
@@ -173,13 +179,13 @@ public class InspectionService {
         return inspectionTypeRepository.save(inspectionType);
     }
 
-    //삭제
+    //수정
     @Transactional
     public void removeType(Long id) {
         InspectionType type = inspectionTypeRepository.findById(id).orElseThrow();
         inspectionTypeRepository.delete(type);
     }
-    //굳이 수정까진 필요한가
+
 
 
 

--- a/backend/src/main/java/com/ohammer/apartner/domain/inspection/service/InspectionUserService.java
+++ b/backend/src/main/java/com/ohammer/apartner/domain/inspection/service/InspectionUserService.java
@@ -1,0 +1,118 @@
+package com.ohammer.apartner.domain.inspection.service;
+
+import com.ohammer.apartner.domain.inspection.dto.InspectionRequestDto;
+import com.ohammer.apartner.domain.inspection.dto.InspectionResponseDetailDto;
+import com.ohammer.apartner.domain.inspection.dto.InspectionUpdateDto;
+import com.ohammer.apartner.domain.inspection.entity.Inspection;
+import com.ohammer.apartner.domain.inspection.entity.InspectionType;
+import com.ohammer.apartner.domain.inspection.entity.Result;
+import com.ohammer.apartner.domain.inspection.repository.InspectionRepository;
+import com.ohammer.apartner.domain.inspection.repository.InspectionTypeRepository;
+import com.ohammer.apartner.domain.user.entity.Role;
+import com.ohammer.apartner.domain.user.entity.User;
+import com.ohammer.apartner.domain.user.repository.UserRepository;
+import com.ohammer.apartner.global.Status;
+import com.ohammer.apartner.security.utils.SecurityUtil;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+//매니저가 아닌 유저의 자가점검 서비스
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class InspectionUserService {
+    private final InspectionService inspectionService;
+    private final InspectionRepository inspectionRepository;
+    private final InspectionTypeRepository inspectionTypeRepository;
+    private final UserRepository userRepository;
+
+    //자기꺼랑 매니저에 대한 공지사항 보기
+    public List<InspectionResponseDetailDto>getAllInspectionWithUser() {
+        Long userId = SecurityUtil.getOptionalCurrentUserId().orElseThrow();
+
+        return  inspectionRepository.findByUserIdOrManager(userId, Role.MODERATOR).stream()
+                .map( r-> new InspectionResponseDetailDto(
+                        r.getId(),
+                        r.getUser().getId(),
+                        r.getUser().getUserName(),
+                        r.getStartAt(),
+                        r.getFinishAt(),
+                        r.getTitle(),
+                        r.getDetail(),
+                        r.getResult(),
+                        r.getType().getTypeName()
+                ))
+                .toList();
+    }
+
+    //자가 점검은 매니저의 그것과 다를 바가 없을 것 같은데
+    //그래도 공지 없는 그건 해줘야지
+
+
+    @Transactional
+    public Inspection newUserInspectionSchedule (InspectionRequestDto dto) {
+        //대충 유저 찾기
+        //원래 통으로 객체를 찾을까 싶었는데, 도용?의 문제가 있을 것 같아서 효율성 깎고 id뽑아서 찾아오는걸루
+        Long userId = SecurityUtil.getOptionalCurrentUserId().orElseThrow();
+
+        User user = userRepository.findById(userId).get();
+
+        InspectionType type = inspectionTypeRepository.findByTypeName(dto.getType());
+
+        Inspection inspection = Inspection.builder()
+                .user(user)
+                .startAt(dto.getStartAt())
+                .finishAt(dto.getFinishAt())
+                .detail(dto.getDetail())
+                .title(dto.getTitle())
+                .type(type)
+                .result(Result.PENDING)
+                .modifiedAt(null)
+                .createdAt(LocalDateTime.now())
+                .status(Status.ACTIVE)
+                .build();
+        return inspectionRepository.save(inspection);
+    }
+
+    //수정
+    @Transactional
+    public void updateInspectionUser(Long id, InspectionUpdateDto dto) {
+
+
+        Inspection inspection = inspectionRepository.findById(id).orElseThrow();
+        Long userId = SecurityUtil.getOptionalCurrentUserId().orElseThrow();
+
+        if (inspection.getUser().getId() != userId)
+            throw new RuntimeException("오직 본인만 수정/삭제가 가능합니다");
+
+        inspection.setDetail(dto.getDetail());
+        inspection.setStartAt(dto.getStartAt());
+        inspection.setFinishAt(dto.getFinishAt());
+        inspection.setModifiedAt(LocalDateTime.now());
+        inspection.setTitle(dto.getTitle());
+
+        inspection.setType(inspectionTypeRepository.findByTypeName(dto.getType()));
+
+        inspection.setResult(inspectionService.findResult(dto.getResult()));
+
+        inspectionRepository.save(inspection);
+    }
+
+    //삭제
+    @Transactional
+    public void deleteUserInspection(Long id) {
+
+        Inspection inspection = inspectionRepository.findById(id).orElseThrow();
+        Long userId = SecurityUtil.getOptionalCurrentUserId().orElseThrow();
+
+        if (inspection.getUser().getId() != userId)
+            throw new RuntimeException("오직 본인만 수정/삭제가 가능합니다");
+        inspection.setStatus(Status.WITHDRAWN);
+        inspectionRepository.save(inspection);
+    }
+}

--- a/backend/src/main/java/com/ohammer/apartner/domain/inspection/service/InspectionUserService.java
+++ b/backend/src/main/java/com/ohammer/apartner/domain/inspection/service/InspectionUserService.java
@@ -35,7 +35,7 @@ public class InspectionUserService {
     public List<InspectionResponseDetailDto>getAllInspectionWithUser() {
         Long userId = SecurityUtil.getOptionalCurrentUserId().orElseThrow();
 
-        return  inspectionRepository.findByUserIdOrManager(userId, Role.MODERATOR).stream()
+        return  inspectionRepository.findByUserIdOrManager(userId, Role.MANAGER).stream()
                 .map( r-> new InspectionResponseDetailDto(
                         r.getId(),
                         r.getUser().getId(),

--- a/backend/src/main/java/com/ohammer/apartner/domain/opinion/service/OpinionService.java
+++ b/backend/src/main/java/com/ohammer/apartner/domain/opinion/service/OpinionService.java
@@ -33,7 +33,7 @@ public class OpinionService {
         Set<Role> userRoles = user.getRoles();
 
         boolean hasRequiredRole = userRoles.stream()
-                .anyMatch(role -> role == Role.ADMIN || role == Role.MODERATOR);
+                .anyMatch(role -> role == Role.ADMIN || role == Role.MANAGER);
 
         if (!hasRequiredRole) {
             throw new AccessDeniedException("전체 민원 목록을 조회할 권한이 없습니다.");

--- a/backend/src/main/java/com/ohammer/apartner/domain/opinion/service/OpinionService.java
+++ b/backend/src/main/java/com/ohammer/apartner/domain/opinion/service/OpinionService.java
@@ -62,7 +62,7 @@ public class OpinionService {
         Set<Role> userRoles = user.getRoles();
 
         boolean hasRequiredRole = userRoles.stream()
-                .anyMatch(role -> role == Role.ADMIN || role == Role.MODERATOR);
+                .anyMatch(role -> role == Role.ADMIN || role == Role.MANAGER);
 
         if (!hasRequiredRole) {
             throw new AccessDeniedException("의견 목록을 조회할 권한이 없습니다.");

--- a/backend/src/main/java/com/ohammer/apartner/domain/user/entity/Role.java
+++ b/backend/src/main/java/com/ohammer/apartner/domain/user/entity/Role.java
@@ -5,7 +5,7 @@ import java.util.Arrays;
 public enum Role {
     ADMIN("admin"),
     USER("user"),
-    MODERATOR("moderator");
+    MANAGER("manager");
 
     private final String value;
 

--- a/backend/src/main/java/com/ohammer/apartner/security/config/SecurityConfig.java
+++ b/backend/src/main/java/com/ohammer/apartner/security/config/SecurityConfig.java
@@ -58,11 +58,11 @@ public class SecurityConfig {
 
                                 "/api/v1/sms/**", // sms 경로는 여기에 유지
                                 "/api/v1/vehicles/**",
-                                "/api/v1/entry-records/**"
+                                "/api/v1/entry-records/**",
 
 
                                 //암시로 넣어야징
-                                "/api/v1/inspection/**",
+                                "/api/v1/inspection/**"
                 
                         ).permitAll()
                         // 관리자 전용 API -> adminSecurityFilterChain에서 처리하므로 이 부분은 제거됨

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -975,12 +975,10 @@
         }
       }
     },
-
     "node_modules/@radix-ui/react-collapsible": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.2.tgz",
       "integrity": "sha512-PliMB63vxz7vggcyq0IxNYk8vGDrLXVWw4+W4B8YnwI1s18x7YZYqlG9PLX7XxAJUi0g2DxP4XKJMFHh/iVh9A==",
-
       "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.1",


### PR DESCRIPTION
* 유저 점검을 추가했습니다
* 유저가 자가점검을 할 수 있습니다(하는 방식은 관리자와 동일)
* 하지만 점검 목록 불러오기는 본인것과 관리자의 것만 불러올 수 있습니다
* 이에 따라 본인만 수정/삭제할 수 있도록 itIsYou란 메서드를 추가했습니다
* 타입 수정/삭제는 없앴습니다 굳이 쓸 필요가 있나 싶어요
* 점검이 삭제될때 Status로 DB에서 삭제가 아닌 Status의 Withdraw처리 시켰습니다
* 너무 덥습니다
* 프론트 어캐하죠