### PR TITLE
토큰이 없는 유저 접근 시 리다이렉트 처리 수정

### DIFF
--- a/backend/src/main/java/com/ohammer/apartner/domain/user/dto/UserWithdrawRequestDto.java
+++ b/backend/src/main/java/com/ohammer/apartner/domain/user/dto/UserWithdrawRequestDto.java
@@ -12,11 +12,16 @@ import lombok.Setter;
 @Schema(description = "회원 탈퇴 요청 DTO")
 public class UserWithdrawRequestDto {
 
-    @NotBlank(message = "비밀번호는 필수입니다.")
     @Schema(description = "사용자 비밀번호", example = "password123!")
     private String password;
 
     @NotBlank(message = "탈퇴 사유는 필수입니다.")
     @Schema(description = "탈퇴 사유", example = "서비스 불만")
     private String leaveReason;
+    
+    @Schema(description = "소셜 로그인 제공자", example = "kakao")
+    private String socialProvider;
+    
+    @Schema(description = "소셜 로그인 사용자 여부", example = "true")
+    private Boolean isSocialUser;
 } 

--- a/backend/src/main/java/com/ohammer/apartner/domain/user/exception/UserErrorCode.java
+++ b/backend/src/main/java/com/ohammer/apartner/domain/user/exception/UserErrorCode.java
@@ -75,7 +75,10 @@ public enum UserErrorCode {
     ALREADY_WITHDRAWN_USER("이미 탈퇴한 회원입니다.", HttpStatus.BAD_REQUEST),
 
     @Schema(description = "비밀번호가 일치하지 않습니다.")
-    PASSWORD_NOT_MATCH("비밀번호가 일치하지 않습니다.", HttpStatus.BAD_REQUEST);
+    PASSWORD_NOT_MATCH("비밀번호가 일치하지 않습니다.", HttpStatus.BAD_REQUEST),
+    
+    @Schema(description = "비밀번호는 필수입니다.")
+    PASSWORD_REQUIRED("비밀번호는 필수입니다.", HttpStatus.BAD_REQUEST);
 
     private final String message;
     private final HttpStatus status;

--- a/frontend/src/components/mobile-menu.tsx
+++ b/frontend/src/components/mobile-menu.tsx
@@ -1,22 +1,23 @@
-"use client"
+"use client";
 
-import { motion } from "framer-motion"
-import Link from "next/link"
-import { X } from "lucide-react"
-import { Button } from "@/components/ui/button"
+import { motion } from "framer-motion";
+import Link from "next/link";
+import { X } from "lucide-react";
+import { Button } from "@/components/ui/button";
 
 interface MobileMenuProps {
-  onClose: () => void
+  onClose: () => void;
 }
 
 export default function MobileMenu({ onClose }: MobileMenuProps) {
   const menuItems = [
     { name: "홈", href: "/" },
-    { name: "서비스", href: "#services" },
-    { name: "공지사항", href: "#notices" },
-    { name: "민원접수", href: "#complaints" },
-    { name: "커뮤니티", href: "#community" },
-  ]
+    { name: "공지사항", href: "/udash/notices" },
+    { name: "민원접수", href: "/udash/complaints" },
+    { name: "공용시설", href: "/udash/facilities" },
+    { name: "차량관리", href: "/udash/vehicles" },
+    { name: "시설점검", href: "/udash/inspections" },
+  ];
 
   return (
     <motion.div
@@ -29,7 +30,9 @@ export default function MobileMenu({ onClose }: MobileMenuProps) {
         <div className="flex items-center justify-between">
           <div className="flex items-center space-x-2">
             <div className="w-8 h-8 rounded-full bg-pink-200 dark:bg-pink-800"></div>
-            <span className="text-xl font-bold dark:text-white">아파트 관리</span>
+            <span className="text-xl font-bold dark:text-white">
+              아파트 관리
+            </span>
           </div>
           <button
             onClick={onClose}
@@ -62,12 +65,16 @@ export default function MobileMenu({ onClose }: MobileMenuProps) {
             animate={{ opacity: 1, y: 0 }}
             transition={{ delay: menuItems.length * 0.1 }}
           >
-            <Button size="lg" onClick={onClose} className="bg-black text-white dark:bg-white dark:text-black">
+            <Button
+              size="lg"
+              onClick={onClose}
+              className="bg-black text-white dark:bg-white dark:text-black"
+            >
               대시보드 가기
             </Button>
           </motion.div>
         </motion.nav>
       </div>
     </motion.div>
-  )
+  );
 }

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+// 정적 파일 및 무시할 경로 패턴
+const STATIC_PATHS = [
+  /\.[^/]+$/, // 확장자가 있는 모든 파일 (이미지, CSS, JS 등)
+  /^\/api\//, // API 경로
+  /^\/admin\//, // 관리자 경로
+  /^\/_next\//, // Next.js 내부 경로
+];
+
+export function middleware(request: NextRequest) {
+  const path = request.nextUrl.pathname;
+
+  // 정적 파일이나 무시할 경로인 경우 통과
+  if (STATIC_PATHS.some((pattern) => pattern.test(path))) {
+    return NextResponse.next();
+  }
+
+  const token = request.cookies.get("accessToken");
+
+  // 인증이 필요 없는 경로들
+  const publicPaths = [
+    "/",
+    "/login",
+    "/signup",
+    "/find-id",
+    "/find-password",
+    "/auth",
+  ];
+
+  // 현재 경로가 public 경로인지 확인
+  const isPublicPath = publicPaths.some(
+    (publicPath) => path === publicPath || path.startsWith(publicPath + "/")
+  );
+
+  // 토큰이 없고 public 경로가 아니면 로그인 페이지로 리다이렉트
+  if (!token && !isPublicPath) {
+    return NextResponse.redirect(new URL("/login", request.url));
+  }
+
+  return NextResponse.next();
+}
+
+// 미들웨어는 페이지 요청에만 적용하고 정적 파일 요청은 건너뜁니다
+export const config = {
+  matcher: [
+    // 모든 경로 - 하지만 정적 파일은 matcher에서 자동으로 제외됨
+    "/(.*)",
+  ],
+};


### PR DESCRIPTION
인증 토큰이 없는 사용자가 보호된 페이지에 접근할 경우, 로그인 페이지(/login)로 리다이렉트되도록 수정했습니다.

기존에는 토큰이 없을 때 예외 처리 또는 빈 페이지가 노출되는 문제가 있었습니다.

라우터 가드를 통해 토큰 유무를 검사하여 비정상 접근을 방지합니다.

